### PR TITLE
BUG: Linking error on Windows

### DIFF
--- a/test/FixedPointInverseDeformationFieldTest.cxx
+++ b/test/FixedPointInverseDeformationFieldTest.cxx
@@ -16,24 +16,6 @@
  *
  *=========================================================================*/
 
-/*=========================================================================
- *
- *  Copyright Insight Software Consortium
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- *=========================================================================*/
-
 #include "itkWin32Header.h"
 #include <iostream>
 #include <fstream>
@@ -44,7 +26,7 @@
 #include "itkFixedPointInverseDeformationFieldImageFilter.h"
 
 
-int FixedPointInverseDeformationFieldTest(int argc, char **argv)
+int FixedPointInverseDeformationFieldTest(int argc, char *argv[])
 {
   if( argc < 3 )
     {


### PR DESCRIPTION
TestDriver main function has to have the following signature:
int {TestDriverFunctionName}(int argv, char\* argc[])
