### PR TITLE
BUG: Shadowed variable

### DIFF
--- a/include/itkFixedPointInverseDisplacementFieldImageFilter.hxx
+++ b/include/itkFixedPointInverseDisplacementFieldImageFilter.hxx
@@ -64,9 +64,8 @@ FixedPointInverseDisplacementFieldImageFilter<TInputImage,TOutputImage>
 
 //----------------------------------------------------------------------------
 template<class TInputImage, class TOutputImage>
-void FixedPointInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData() {
-
-  const unsigned int ImageDimension = InputImageType::ImageDimension;
+void FixedPointInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::GenerateData()
+{
 
   InputImageConstPointer inputPtr = this->GetInput(0);
   OutputImagePointer outputPtr = this->GetOutput(0);


### PR DESCRIPTION
ImageDimension was declared both as a member variable of the class
and inside GenerateData().
